### PR TITLE
Specify /tmp for get-join-files.sh

### DIFF
--- a/ansible/roles/master/get-join-files/tasks/main.yml
+++ b/ansible/roles/master/get-join-files/tasks/main.yml
@@ -1,11 +1,11 @@
 - name: Copy get-join-files.sh
   copy:
     src: get-join-files.sh
-    dest: get-join-files.sh
+    dest: /tmp/get-join-files.sh
     mode: 0755
 
 - name: Execute get-join-files.sh
-  shell: ./get-join-files.sh
+  shell: /tmp/get-join-files.sh
   become: yes
 
 - name: Fetch join-files.tar.gz


### PR DESCRIPTION
The task "Copy get-join-files.sh" was failed with the error message
"Destination directory  does not exist". So it is nice to specify
/tmp as a full path for most Linux distributions.

Fixes: #3